### PR TITLE
Change the execution phase of plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
-                        <phase>verify</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
@@ -218,7 +218,7 @@
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
-                        <phase>verify</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>


### PR DESCRIPTION
Missing signature on javadoc and source jars. The signing has been done during verify phase, so we will change the phase for javadoc and source plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/58)
<!-- Reviewable:end -->
