### PR TITLE
Add more dependencies to `dependencyManagement` section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,22 @@
                 <artifactId>iron-media-query</artifactId>
                 <version>2.1.0</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.webjars.bowergithub.polymer</groupId>
+                <artifactId>polymer</artifactId>
+                <version>2.6.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.bowergithub.webcomponents</groupId>
+                <artifactId>webcomponentsjs</artifactId>
+                <version>1.2.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars.bowergithub.webcomponents</groupId>
+                <artifactId>shadycss</artifactId>
+                <version>1.2.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -591,17 +607,14 @@
         <dependency>
             <groupId>org.webjars.bowergithub.polymer</groupId>
             <artifactId>polymer</artifactId>
-            <version>2.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.webcomponents</groupId>
             <artifactId>webcomponentsjs</artifactId>
-            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.webcomponents</groupId>
             <artifactId>shadycss</artifactId>
-            <version>1.2.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Pro tools custom components prefer to use flow-component-base as a bom file hence need to have basic polymer dependencies fixed there for consistency.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/67)
<!-- Reviewable:end -->
