### PR TITLE
Update vaadin-grid to 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>
                 <artifactId>vaadin-grid</artifactId>
-                <version>5.1.0</version>
+                <version>5.2.1</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.webjars.bowergithub.polymerelements</groupId>


### PR DESCRIPTION
The `vaadin-grid-flow` project v.2.1 depends on the fixes introduced in the version for the webcomponent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/91)
<!-- Reviewable:end -->
