### PR TITLE
Bump text-field to 2.3.0-alpha2 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>
                 <artifactId>vaadin-text-field</artifactId>
-                <version>2.3.0-alpha1</version>
+                <version>2.3.0-alpha2</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
Bump text-field dependency to 2.3.0-alpha2 with fixed clear button

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/107)
<!-- Reviewable:end -->
