### PR TITLE
Making component projects compatible with JDK 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flow-component-base</artifactId>
@@ -25,15 +25,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8
         </project.reporting.outputEncoding>
-
-        <!-- 9.4.X version is causing component builds fail on cannot connect 
-            to server -->
-        <jetty.version>9.3.24.v20180605</jetty.version>
-        <maven.failsafe.plugin.version>2.20</maven.failsafe.plugin.version>
-        <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
-        <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
-        <driver.binary.downloader.maven.plugin.version>1.0.14
-        </driver.binary.downloader.maven.plugin.version>
 
         <!-- OSGi support -->
         <osgi.bundle.import.package>*</osgi.bundle.import.package>
@@ -315,7 +306,8 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
+                 <!-- 9.4.X version only supports war projects -->
+                <version>9.3.25.v20180904</version>
                 <configuration>
                     <httpConnector>
                         <port>9998</port>
@@ -325,7 +317,7 @@
                     <stopWait>5</stopWait>
                     <stopKey>foo</stopKey>
                     <!-- Use TestScope because the test classes are in the 
-                        test package. -->
+                    test package. -->
                     <useTestScope>true</useTestScope>
                     <webAppConfig>
                         <containerIncludeJarPattern>^$</containerIncludeJarPattern>
@@ -333,7 +325,7 @@
                 </configuration>
                 <executions>
                     <!-- start and stop jetty (running our app) when running 
-                        integration tests -->
+                    integration tests -->
                     <execution>
                         <id>start-jetty</id>
                         <phase>pre-integration-test</phase>
@@ -353,7 +345,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${maven.failsafe.plugin.version}</version>
+                <version>2.22.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -370,7 +362,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>${maven.resources.plugin.version}</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>copy-resources-for-demo-website</id>
@@ -430,7 +422,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -546,6 +538,14 @@
             <version>${flow.version}</version>
             <scope>test</scope>
         </dependency>
+        
+        <!-- JDK 9+ nees this for @Generated annotation, added by the flow component generator -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.webjars.bowergithub.polymer</groupId>
@@ -654,7 +654,7 @@
                     <plugin>
                         <groupId>com.lazerycode.selenium</groupId>
                         <artifactId>driver-binary-downloader-maven-plugin</artifactId>
-                        <version>${driver.binary.downloader.maven.plugin.version}</version>
+                        <version>1.0.17</version>
                         <configuration>
                             <onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
                             <rootStandaloneServerDirectory>${project.build.directory}/driver</rootStandaloneServerDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
                 </executions>
                 <configuration>
                     <quiet>true</quiet>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Individual component projects still need to start using this version (they currently seem to refer 1.2-SNAPSHOT).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/113)
<!-- Reviewable:end -->
