### PR TITLE
Bump vaadin-list-mixin to 2.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>
                 <artifactId>vaadin-list-mixin</artifactId>
-                <version>2.1.1</version>
+                <version>2.1.2</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
https://repo1.maven.org/maven2/org/webjars/bowergithub/vaadin/vaadin-list-mixin/2.1.2/

The old version breaks context-menu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/123)
<!-- Reviewable:end -->
