### PR TITLE
Remove the unnecessary flow version from base

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,6 @@
     </parent>
 
     <properties>
-        <!-- Should be overridden in child modules -->
-        <flow.version>1.3-SNAPSHOT</flow.version>
-
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
After the component repo refactoring, the flow version is not needed any more

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/135)
<!-- Reviewable:end -->
