### PR TITLE
Remove vaadin-components-testbench

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,11 +521,6 @@
                 <version>${testbench.version}</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>vaadin-components-testbench</artifactId>
-                <version>2.0.2</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
vaadin-components-testbench was removed from every component repo as part of vaadin/testbench#1188
old version should also be removed from flow-component-base before stable releases

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/142)
<!-- Reviewable:end -->
