### PR TITLE
Update version to 2.0.4 which is the correct one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -555,7 +555,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-development-mode-detector</artifactId>
-            <version>2.0.3</version>
+            <version>2.0.4</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -550,7 +550,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-usage-statistics</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
Sorry about the mess. The fix by @alvarezguille was reverted and 2.0.4 is the same as 2.0.2
But let's update to the latest version explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/154)
<!-- Reviewable:end -->
