### PR TITLE
Update vaadin-usage-statistics to 2.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,7 +550,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-usage-statistics</artifactId>
-            <version>2.0.5</version>
+            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
2.0.5 for some reason contains a broken webjar in Maven central (inconsistent archive)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/157)
<!-- Reviewable:end -->
