### PR TITLE
Revert "Bump vaadin-usage-statistics to 2.0.8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -550,7 +550,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-usage-statistics</artifactId>
-            <version>2.0.8</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>


### PR DESCRIPTION
Reverts vaadin/flow-component-base#160

webjar for vaadin-usage-statistics 2.0.8 is not working

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/161)
<!-- Reviewable:end -->
