### PR TITLE
Bump to 3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flow-component-base</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Flow component base</name>
     <description>Parent pom for individual component modules</description>
@@ -28,7 +28,7 @@
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <driver.binary.downloader.maven.plugin.version>1.0.14
         </driver.binary.downloader.maven.plugin.version>
-        <flow.version>2.1-SNAPSHOT</flow.version>
+        <flow.version>3.0-SNAPSHOT</flow.version>
         <testbench.version>6.2.1</testbench.version>
 
         <!-- OSGi support -->
@@ -520,42 +520,4 @@
         </dependencies>
     </dependencyManagement>
 
-    <dependencies>
-        <!-- there should be a way to remove this when in npm-mode -->
-        <dependency>
-            <groupId>org.webjars.bowergithub.polymer</groupId>
-            <artifactId>polymer</artifactId>
-            <version>2.6.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.bowergithub.webcomponents</groupId>
-            <artifactId>webcomponentsjs</artifactId>
-            <version>1.2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.bowergithub.webcomponents</groupId>
-            <artifactId>shadycss</artifactId>
-            <version>1.5.0-1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.bowergithub.vaadin</groupId>
-            <artifactId>vaadin-element-mixin</artifactId>
-            <!--  IMPORTANT NOTE: if you update this version check that
-               transitive dependencies (mvn dependency:tree) versions are
-               also the most recent ones: see below. At the moment these are
-               two deps "vaadin-usage-statistics" and
-               "vaadin-development-mode-detector"  -->
-            <version>2.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.bowergithub.vaadin</groupId>
-            <artifactId>vaadin-usage-statistics</artifactId>
-            <version>2.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.webjars.bowergithub.vaadin</groupId>
-            <artifactId>vaadin-development-mode-detector</artifactId>
-            <version>2.0.4</version>
-        </dependency>
-    </dependencies>
 </project>


### PR DESCRIPTION
Removes webjars and uses Flow 3.0.

Part of vaadin/flow#7338

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/168)
<!-- Reviewable:end -->
