### PR TITLE
Update javadoc-plugin for java 9+ compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.0.1</version>
                     <executions>
                         <execution>
                             <id>attach-javadocs</id>
@@ -130,7 +130,7 @@
                     </executions>
                     <configuration>
                         <quiet>true</quiet>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <doclint>none</doclint>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
doclint configuration was added in 3.0.0 https://maven.apache.org/plugins/maven-javadoc-plugin/javadoc-mojo.html#doclint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/174)
<!-- Reviewable:end -->
