### PR TITLE
Prepare for V14.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flow-component-base</artifactId>
-    <version>2.3-SNAPSHOT</version>
+    <version>2.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Flow component base</name>
     <description>Parent pom for individual component modules</description>
@@ -28,8 +28,8 @@
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <driver.binary.downloader.maven.plugin.version>1.0.14
         </driver.binary.downloader.maven.plugin.version>
-        <flow.version>2.3-SNAPSHOT</flow.version>
-        <testbench.version>6.2.2</testbench.version>
+        <flow.version>2.4.hashelper-SNAPSHOT</flow.version>
+        <testbench.version>6.4-SNAPSHOT</testbench.version>
 
         <!-- OSGi support -->
         <osgi.bundle.import.package>*</osgi.bundle.import.package>

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
             <name>Vaadin release staging repository</name>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
-        <snapshotRepository>
-            <id>vaadin-snapshots</id>
-            <name>Vaadin snapshot repository</name>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
-        </snapshotRepository>
     </distributionManagement>
 
     <repositories>
@@ -67,13 +62,12 @@
         <repository>
             <id>vaadin-prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <id>vaadin-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -88,12 +82,11 @@
             <id>vaadin-prereleases</id>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>vaadin-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </pluginRepository>
     </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <driver.binary.downloader.maven.plugin.version>1.0.14
         </driver.binary.downloader.maven.plugin.version>
         <flow.version>2.4.hashelper-SNAPSHOT</flow.version>
-        <testbench.version>6.4-SNAPSHOT</testbench.version>
+        <testbench.version>6.4.0.alpha1</testbench.version>
 
         <!-- OSGi support -->
         <osgi.bundle.import.package>*</osgi.bundle.import.package>


### PR DESCRIPTION
To make it easier to implement the components with the helper feature:
- use `flow@2.4.hashelper-SNAPSHOT`
- use `testbench@6.4-SNAPSHOT` with `HasHelper` interface

Blocked by https://github.com/vaadin/testbench/pull/1266

Fix #187 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow-component-base/186)
<!-- Reviewable:end -->
